### PR TITLE
Fix on format pad hour

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ export function parseStringFormat(stringFormat: string): Array<string> {
   return matchedFormats;
 }
 
-const PADDED_FORMATS: Array<string> = ['hh', 'DD', 'mm', 'ss', 'hh'];
+const PADDED_FORMATS: Array<string> = ['hh', 'DD', 'mm', 'ss', 'HH'];
 const FORMATS: any = {
   YYYY: { year: 'numeric' },
   YYY: { year: 'numeric' },


### PR DESCRIPTION
Hello 👋  

Previously, thank you for creating this library. When I opened the source code I found something out of the ordinary:

```
const PADDED_FORMATS: Array<string> = ['hh', 'DD', 'mm', 'ss', 'hh'];
                                                                                                             ^ there is duplicate value
```

when i think it must be, i think ...

```
const PADDED_FORMATS: Array<string> = ['hh', 'DD', 'mm', 'ss', 'HH'];
```

these value based on moment source code, which you can see on  [here](https://github.com/moment/moment/blob/2e2a5b35439665d4b0200143d808a7c26d6cd30f/src/lib/units/hour.js#L22)